### PR TITLE
bugfix: Fixed filepath for a Starlight Project

### DIFF
--- a/data.ts
+++ b/data.ts
@@ -245,7 +245,7 @@ export const starlightProjectData: Omit<ProjectCardProps, "trainee">[] = [
     name: "Groveify - 24T1 Trainee Project",
     desc: "Groveify is a habit tracker and productivity manager that comes with a cute little world to keep you going!",
     projectUrl: "https://groveify.com",
-    thumbnailUrl: "/traineeProjects/Groveify.png",
+    thumbnailUrl: "/traineeProjects/groveify.png",
   },
   {
     name: "Generic Assembler",


### PR DESCRIPTION
Incorrectly capitalised file path works on a dev environment but not in prod

- Adjusted file path to point to the correct location